### PR TITLE
Update Maven to Spigot 1.8 and WorldEdit 6

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -5,5 +5,5 @@ main: org.mcsg.double0negative.supercraftbros.SuperCraftBros
 commands:
   scb:
     description: Super Craft Bros
-    usage: /scb(command) (args)
+    usage: /scb (command) (args)
     aliases: [scb]

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>com.sk89q</groupId>
 			<artifactId>worldedit</artifactId>
-			<version>5.5.7-SNAPSHOT</version>
+			<version>6.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mcstats.bukkit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,23 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>org.mcsg</groupId>
 	<artifactId>SuperCraftBros</artifactId>
-	<version>000</version>
+	<version>1.8.7-R0.1-SNAPSHOT</version>
 	<name>SuperCraftBros</name>
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<upload.dbo.category>server-mods</upload.dbo.category>
-		<upload.dbo.slug>survival-games</upload.dbo.slug>
-
-	</properties>
 	<repositories>
-		<repository>
-			<id>bukkit-repo</id>
-			<url>http://repo.bukkit.org/content/groups/public</url>
-		</repository> <!-- <repository> <id>mcstats-repo</id> <url>http://repo.mcstats.org/content/repositories/public</url> 
-			</repository> -->
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+        </repository>
 		<repository>
 			<id>drtshock-repo</id>
 			<url>http://ci.drtshock.net/plugin/repository/everything</url>
@@ -31,63 +25,68 @@
 			<url>http://repo.mcstats.org/content/repositories/public</url>
 		</repository>
 	</repositories>
-	<build>
-		<plugins> <!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-shade-plugin</artifactId> 
-				<version>1.5</version> <configuration> <artifactSet> <includes> <include>org.mcstats:Metrics</include> 
-				</includes> </artifactSet> <relocations> <relocation> <pattern>org.mcstats</pattern> 
-				<shadedPattern>libilibigot.utilzbiznatch.metrics</shadedPattern> </relocation> 
-				</relocations> </configuration> <executions> <execution> <phase>package</phase> 
-				<goals> <goal>shade</goal> </goals> </execution> </executions> </plugin> -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.0.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.1</version>
-				<configuration>
-					<archive>
-						<addMavenDescriptor>false</addMavenDescriptor>
-					</archive>
-					<finalName>${project.name}</finalName>
-				</configuration>
-			</plugin>
-		</plugins>
-		<resources>
-			<resource>
-				<targetPath>.</targetPath>
-				<filtering>true</filtering>
-				<directory>${basedir}/src/main/resources</directory>
-				<includes>
-					<include>*.yml</include>
-				</includes>
-			</resource>
-			<resource>
-				<targetPath>.</targetPath>
-				<directory>${basedir}</directory>
-				<includes>
-					<include>LICENSE</include>
-				</includes>
-			</resource>
-		</resources>
-	</build>
+
+    <profiles>
+        <profile>
+            <id>org.mcsg.double0negative.supercraftbros</id>
+            <build>
+                <finalName>SuperCraftBros</finalName>
+                <directory>src/main/java/</directory>
+                <resources>
+                    <resource>
+                        <targetPath>.</targetPath>
+                        <filtering>true</filtering>
+                        <directory>${basedir}/src/main/resources/</directory>
+                        <includes>
+                            <include>*.yml</include>
+                        </includes>
+                    </resource>
+                    <resource>
+                        <targetPath>.</targetPath>
+                        <directory>${basedir}</directory>
+                        <includes>
+                            <include>LICENSE</include>
+                        </includes>
+                    </resource>
+                </resources>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <source>1.7</source>
+                            <target>1.7</target>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>2.1</version>
+                        <configuration>
+                            <archive>
+                                <addMavenDescriptor>false</addMavenDescriptor>
+                            </archive>
+                            <finalName>${project.name}</finalName>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 	<dependencies>
-		<dependency>
-			<groupId>org.bukkit</groupId>
-			<artifactId>bukkit</artifactId>
-			<version>1.7.9-R0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.bukkit</groupId>
-			<artifactId>craftbukkit</artifactId>
-			<version>1.7.9-R0.2</version>
-		</dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.8.7-R0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bukkit</groupId>
+            <artifactId>bukkit</artifactId>
+            <version>1.8.7-R0.1-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
 		<dependency>
 			<groupId>com.sk89q</groupId>
 			<artifactId>worldedit</artifactId>
@@ -96,10 +95,10 @@
 		<dependency>
 			<groupId>org.mcstats.bukkit</groupId>
 			<artifactId>metrics</artifactId>
-			<version>R6</version>
+			<version>R8-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
-
 	</dependencies>
+
 </project>
 


### PR DESCRIPTION
These changes primarily concern updating the APIs for the plugin going forward. Using the latest version of the Bukkit/Spigot API will enable you to tap into features specific to 1.8, and WorldEdit is moving very quickly away from v5 to v6, so supporting the latest WorldEdit API is also very important.
