### PR TITLE
Add CraftBukkit dependency for NMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bukkit</groupId>
+            <artifactId>craftbukkit</artifactId>
+            <version>1.8.7-R0.1-SNAPSHOT</version>
+        </dependency>
 		<dependency>
 			<groupId>com.sk89q</groupId>
 			<artifactId>worldedit</artifactId>


### PR DESCRIPTION
Forgot an important dependency in the POM file for CraftBukkit. This is needed to build the project with NMS data, otherwise building with Maven will fail because CraftBukkit is needed to compile.

I tested this with `mvn clean package` locally and I successfully built the project.
