### PR TITLE
Update for Spigot 1.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,6 @@ For more information about this plugin and how to use it, please see our [wiki](
 
 *Maintainer*: @[nextinfinity](https://github.com/nextinfinity/)
 
+*Contributor*: @[quinnshultz](https://github.com/quinnshultz/)
+
 *Documentation*: @[jflory7](https://github.com/jflory7/)

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
     mavenLocal()
 }
 dependencies {
-   compile(group: 'org.spigotmc', name: 'spigot', version:'1.12.1-R0.1-SNAPSHOT')
+   compile(group: 'org.spigotmc', name: 'spigot', version:'1.12.2-R0.1-SNAPSHOT')
    compile(group: 'net.milkbowl.vault', name: 'VaultAPI', version:'1.6')
    compile(group: 'com.sk89q.worldedit', name: 'worldedit-bukkit', version:'6.1.5')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 group = 'org.mcsg.double0negative'
-version = '1.6.6'
+version = '1.7.0'
 defaultTasks "jar"
 
 repositories {         
@@ -12,7 +12,7 @@ repositories {
     mavenLocal()
 }
 dependencies {
-   compile(group: 'org.spigotmc', name: 'spigot', version:'1.11.2-R0.1-SNAPSHOT')
+   compile(group: 'org.spigotmc', name: 'spigot', version:'1.12-R0.1-SNAPSHOT')
    compile(group: 'net.milkbowl.vault', name: 'VaultAPI', version:'1.6')
    compile(group: 'com.sk89q.worldedit', name: 'worldedit-bukkit', version:'6.1.5')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 group = 'org.mcsg.double0negative'
-version = '1.7.0'
+version = '1.7.1'
 defaultTasks "jar"
 
 repositories {         

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
     mavenLocal()
 }
 dependencies {
-   compile(group: 'org.spigotmc', name: 'spigot', version:'1.12-R0.1-SNAPSHOT')
+   compile(group: 'org.spigotmc', name: 'spigot', version:'1.12.1-R0.1-SNAPSHOT')
    compile(group: 'net.milkbowl.vault', name: 'VaultAPI', version:'1.6')
    compile(group: 'com.sk89q.worldedit', name: 'worldedit-bukkit', version:'6.1.5')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 group = 'org.mcsg.double0negative'
-version = '1.7.0'
+version = '1.7.2'
 defaultTasks "jar"
 
 repositories {         

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: SuperCraftBros
 authors: [Double0negative, MCSG, NextInfinity, quinnshultz]
-version: 1.7.1
+version: 1.7.2
 main: org.mcsg.double0negative.supercraftbros.SuperCraftBros
 commands:
   scb:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: SuperCraftBros
 authors: [Double0negative, MCSG, NextInfinity, quinnshultz]
-version: 1.7.0
+version: 1.7.1
 main: org.mcsg.double0negative.supercraftbros.SuperCraftBros
 commands:
   scb:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: SuperCraftBros
-authors: [Double0negative, MCSG, NextInfinity]
-version: 1.6.6
+authors: [Double0negative, MCSG, NextInfinity, quinnshultz]
+version: 1.7.0
 main: org.mcsg.double0negative.supercraftbros.SuperCraftBros
 commands:
   scb:


### PR DESCRIPTION
I have updated the dependencies to compile for CraftBukkit / Spigot 1.12.2. I currently working on replacing deprecated methods, fixing calls to methods that no longer exist, and unit testing in order to build for 1.13.2.